### PR TITLE
meta option for metadata that applies across all logs in session.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 before_install: "! grep PLEASE_FILL_IN_HERE README.md"
 node_js:
-  - '6'
   - '8'
+  - '10'

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Class to manage a single logging session that collects logs and flushes them to
 <a name="new_AMQPLogger_new"></a>
 
 ### new AMQPLogger(config)
-config
-source - the source you are logging from
-amqp.url - the url of the rabbitmq server
-amqp.exchange - the exchange that will be asserted and used to publish to
-amqp.routingKey - the RK to publish logs to
-schemaVersion - schema version to use. Valid values are 2, 3.
+- config
+  - source - the source you are logging from
+  - amqp.url - the url of the rabbitmq server
+  - amqp.exchange - the exchange that will be asserted and used to publish to
+  - amqp.routingKey - the RK to publish logs to
+  - schemaVersion - schema version to use. Valid values are 2, 3.
 
 
 | Param | Type |

--- a/README.md
+++ b/README.md
@@ -33,28 +33,46 @@ there are fields that apply across the whole session the you want to normalise f
 any reason.
 
 ## API
-<a name="main"></a>
+<a name="AMQPLogger"></a>
 
-## main(config)
-Calling this with given config returns a function getLogger().
-When called, getLogger will return an object:
-{log, flush}
-Call log to append logs.
-Call flush to manually flush (you must do this.)
+## AMQPLogger
+Class to manage a single logging session that collects logs and flushes them to
+ AMQP.
 
+**Kind**: global class
+
+* [AMQPLogger](#AMQPLogger)
+    * [new AMQPLogger(config)](#new_AMQPLogger_new)
+    * [.log()](#AMQPLogger+log)
+    * [.flush()](#AMQPLogger+flush)
+
+<a name="new_AMQPLogger_new"></a>
+
+### new AMQPLogger(config)
 config
 source - the source you are logging from
 amqp.url - the url of the rabbitmq server
 amqp.exchange - the exchange that will be asserted and used to publish to
 amqp.routingKey - the RK to publish logs to
-schemaVersion = The schema version for the logging payload.  Currently supported
-values are 2 and 3.
+schemaVersion - schema version to use. Valid values are 2, 3.
 
-**Kind**: global function
 
 | Param | Type |
 | --- | --- |
 | config | <code>Object</code> |
+
+<a name="AMQPLogger+log"></a>
+
+### amqpLogger.log()
+Add a log to the current state.
+
+**Kind**: instance method of [<code>AMQPLogger</code>](#AMQPLogger)
+<a name="AMQPLogger+flush"></a>
+
+### amqpLogger.flush()
+Flush logs to AMQP as a single message.
+
+**Kind**: instance method of [<code>AMQPLogger</code>](#AMQPLogger)
 
 Note: To regenerate this section from the jsdoc run `npm run docs` and paste
 the output above.

--- a/README.md
+++ b/README.md
@@ -13,18 +13,17 @@ const config = {
   source: 'my-source',
   amqp: { url: 'amqp://user:pw@myserver/blah', exchange: 'myexchange', routingKey: 'keyToRouteTo' }
 };
-const loggerConfig = { meta: {/*...*/} };
 const Logger = require('log2amqp')(config);
 let logger = Logger(loggerConfig);
 payload = { this: 'thing'};
 logger.log('kind', payload);
 logger.log('kind2', 'chris');
-logger.flush().then(() => {
+logger.flush({ meta: {/* ... */} }).then(() => {
   // [{ kind: payload }, { kind2: 'chris' }] is flushed to amqp routingKey
 });
 ```
 
-`logerConfig.meta` defines an object you want to apply to the whole logger
+`meta` defines an object you want to apply to the whole logger
 session. It will be included at the top level in the logged payload (same level
 as `logs`).
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ const config = {
   source: 'my-source',
   amqp: { url: 'amqp://user:pw@myserver/blah', exchange: 'myexchange', routingKey: 'keyToRouteTo' }
 };
+const loggerConfig = { meta: {/*...*/} };
 const Logger = require('log2amqp')(config);
-let logger = Logger();
+let logger = Logger(loggerConfig);
 payload = { this: 'thing'};
 logger.log('kind', payload);
 logger.log('kind2', 'chris');
@@ -22,6 +23,10 @@ logger.flush().then(() => {
   // [{ kind: payload }, { kind2: 'chris' }] is flushed to amqp routingKey
 });
 ```
+
+`logerConfig.meta` defines an object you want to apply to the whole logger
+session. It will be included at the top level in the logged payload (same level
+as `logs`).
 
 ## API
 <a name="main"></a>
@@ -87,4 +92,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # log2amqp [![Build Status](https://travis-ci.org/noblesamurai/node-log2amqp.svg?branch=master)](http://travis-ci.org/noblesamurai/node-log2amqp) [![NPM version](https://badge-me.herokuapp.com/api/npm/log2amqp.png)](http://badges.enytc.com/for/npm/log2amqp)
 
-> Log json data to amqp.
+> Log JSON data to AMQP.
 
 ## Purpose
 
-Use this for data dumps to amqp.
+Use this for data dumps to AMQP.
 
 ## Usage
 
 ```js
 const config = {
   source: 'my-source',
-  amqp: { url: 'amqp://user:pw@myserver/blah', exchange: 'myexchange', routingKey: 'keyToRouteTo' }
+  amqp: { url: 'amqp://user:pw@myserver/blah', exchange: 'myexchange', routingKey: 'keyToRouteTo',
+  schemaVersion: 3
+ }
 };
 const Logger = require('log2amqp')(config);
 let logger = Logger();
@@ -25,7 +27,10 @@ logger.flush({ meta: {/* ... */} }).then(() => {
 
 `meta` defines an object you want to apply to the whole logger
 session. It will be included at the top level in the logged payload (same level
-as `logs`).
+as `logs`). You may want to do this so you can e.g. easily index certain fields
+in the JSON payload  (if you are writing from the queue to a DB table) or just if
+there are fields that apply across the whole session the you want to normalise for
+any reason.
 
 ## API
 <a name="main"></a>
@@ -42,6 +47,8 @@ source - the source you are logging from
 amqp.url - the url of the rabbitmq server
 amqp.exchange - the exchange that will be asserted and used to publish to
 amqp.routingKey - the RK to publish logs to
+schemaVersion = The schema version for the logging payload.  Currently supported
+values are 2 and 3.
 
 **Kind**: global function
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ const config = {
   amqp: { url: 'amqp://user:pw@myserver/blah', exchange: 'myexchange', routingKey: 'keyToRouteTo' }
 };
 const Logger = require('log2amqp')(config);
-let logger = Logger(loggerConfig);
+let logger = Logger();
 payload = { this: 'thing'};
 logger.log('kind', payload);
 logger.log('kind2', 'chris');

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function getAmqp (config) {
 function main (config) {
   const _amqp = getAmqp(config);
 
-  return function getLogger () {
+  return function getLogger (logConfig = {}) {
     let flushed = false;
     let logs = [];
 
@@ -44,13 +44,14 @@ function main (config) {
         flushed = true;
         const amqp = await _amqp;
         if (amqp === 'failed') return;
-        console.log(amqp, amqp.publish);
-        await amqp.publish(config.amqp.routingKey, {
+        const payload = {
           id: uuid(),
           timestamp: Date.now(),
-          'log2amqp-schema-version': '2.0.0',
+          'log2amqp-schema-version': '2.1.0',
           source: config.source,
-          logs });
+          logs };
+        if (logConfig.meta) payload.meta = logConfig.meta;
+        await amqp.publish(config.amqp.routingKey, payload);
       } catch (err) {
         debug(err);
       } finally {

--- a/index.js
+++ b/index.js
@@ -34,11 +34,12 @@ async function getAmqp (config) {
 function main (config) {
   const _amqp = getAmqp(config);
 
-  return function getLogger (logConfig = {}) {
+  return function getLogger () {
     let flushed = false;
     let logs = [];
 
-    async function flush () {
+    async function flush (opts = {}) {
+      const { meta } = opts;
       if (flushed) throw new Error('Already flushed.');
       try {
         flushed = true;
@@ -50,7 +51,7 @@ function main (config) {
           'log2amqp-schema-version': '2.1.0',
           source: config.source,
           logs };
-        if (logConfig.meta) payload.meta = logConfig.meta;
+        if (meta) payload.meta = meta;
         await amqp.publish(config.amqp.routingKey, payload);
       } catch (err) {
         debug(err);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/noblesamurai/node-log2amqp/issues"
   },
   "engines": {
-    "node": ">=6.0",
+    "node": ">=8.0",
     "npm": "3.x"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,15 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "dirty-chai": "^1.2.2",
     "jsdoc-to-markdown": "~3.0.0",
-    "mocha": "~3.3.0",
+    "mocha": "^5.2.0",
     "nyc": "^10.1.2",
     "proxyquire": "^1.7.11",
     "semistandard": "*",
-    "sinon": "^2.2.0"
+    "sinon": "^6.1.4"
   },
   "keywords": [],
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "3.0.0-0",
+  "version": "3.0.0-meta.0",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^1.2.2",
-    "jsdoc-to-markdown": "~3.0.0",
+    "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^5.2.0",
     "nyc": "^10.1.2",
     "proxyquire": "^1.7.11",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "version": "2.1.0-meta.1",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "coverage": "nyc -a -c -r html -r text npm test",
     "pretest": "semistandard --env mocha",
     "test": "mocha --recursive test",
     "watch": "mocha --recursive --watch test",
-    "docs": "jsdoc2md index.js"
+    "docs": "jsdoc2md src/index.js"
   },
   "homepage": "https://github.com/noblesamurai/node-log2amqp",
   "repository": {
@@ -27,6 +27,7 @@
   "dependencies": {
     "amqp-wrapper": "^5.5.0",
     "debug": "^2.6.6",
+    "joi": "^13.5.2",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "2.1.0-meta.0",
+  "version": "2.1.0-meta.1",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "2.1.0-meta.2",
+  "version": "3.0.0-0",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
       "coverage",
       "test"
     ]
+  },
+  "semistandard": {
+    "env": [
+      "mocha"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "3.0.0-meta.0",
+  "version": "3.0.0-meta.1",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "2.1.0-meta.1",
+  "version": "2.1.0-meta.2",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log2amqp",
   "description": "Log json data to amqp from express routes.",
-  "version": "2.0.0",
+  "version": "2.1.0-meta.0",
   "author": "Tim Allen <tim@noblesamurai.com>",
   "license": "BSD",
   "main": "index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,13 @@ async function getAmqp (config) {
   }
 }
 
+function validateConfig (config) {
+  joi.assert(config, joi.object({
+    source: joi.string().required(),
+    schemaVersion: joi.number().integer().valid([2, 3]).required()
+  }).unknown(true));
+}
+
 /**
  * @param {Object} config
  * @description
@@ -34,11 +41,7 @@ async function getAmqp (config) {
  * schemaVersion - schema version to use
  */
 function main (config) {
-  joi.assert(config, joi.object({
-    source: joi.string().required(),
-    schemaVersion: joi.number().integer().valid([2, 3]).required()
-  }).unknown(true));
-
+  validateConfig(config);
   const _amqp = getAmqp(config);
 
   return function getLogger () {

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,6 @@ async function flush (state, loggerState, opts = {}) {
     const amqp = await state.amqp;
     if (amqp === 'failed') return;
     const payload = formatPayload(state.config, loggerState.logs);
-    // FIXME(tim): Should handle this more nicely.
     if (meta) payload.meta = meta;
     await amqp.publish(state.config.amqp.routingKey, payload);
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,10 @@ async function getAmqp (config) {
  */
 function main (config) {
   joi.assert(config, joi.object({
+    source: joi.string().required(),
     schemaVersion: joi.number().integer().valid([2, 3]).required()
   }).unknown(true));
+
   const _amqp = getAmqp(config);
 
   return function getLogger () {

--- a/src/payload.js
+++ b/src/payload.js
@@ -1,33 +1,27 @@
-const joi = require('joi');
 const uuid = require('uuid/v1');
 
-module.exports = function formatPayload (config, logs) {
-  joi.assert(config, joi.object({
-    source: joi.string(),
-    schemaVersion: joi.number().integer()
-  }).unknown(true));
-
-  const payload = {
+function common (config) {
+  return {
     id: uuid(),
     timestamp: Date.now(),
     source: config.source
   };
+}
+
+module.exports = function formatPayload (config, logs) {
   if (config.schemaVersion === 2) {
-    const _logs = logs;
-    Object.assign(payload, {
+    return Object.assign(common(config), {
       'log2amqp-schema-version': '2.1.0',
-      logs: _logs.map(l => {
+      logs: logs.map(l => {
         const ret = {};
         ret[l.type] = l.data;
         return ret;
       })
     });
-    return payload;
   } else if (config.schemaVersion === 3) {
-    const _logs = logs;
-    return Object.assign(payload, {
+    return Object.assign(common(config), {
       'log2amqp-schema-version': '3.0.0',
-      logs: _logs
+      logs
     });
   }
   throw new Error(`Unsupported schema version ${config.schemaVersion}`);

--- a/src/payload.js
+++ b/src/payload.js
@@ -12,11 +12,7 @@ module.exports = function formatPayload (config, logs) {
   if (config.schemaVersion === 2) {
     return Object.assign(common(config), {
       'log2amqp-schema-version': '2.1.0',
-      logs: logs.map(l => {
-        const ret = {};
-        ret[l.type] = l.data;
-        return ret;
-      })
+      logs: logs.map(({ type, data }) => ({ [type]: data }))
     });
   } else if (config.schemaVersion === 3) {
     return Object.assign(common(config), {

--- a/src/payload.js
+++ b/src/payload.js
@@ -1,0 +1,34 @@
+const joi = require('joi');
+const uuid = require('uuid/v1');
+
+module.exports = function formatPayload (config, logs) {
+  joi.assert(config, joi.object({
+    source: joi.string(),
+    schemaVersion: joi.number().integer()
+  }).unknown(true));
+
+  const payload = {
+    id: uuid(),
+    timestamp: Date.now(),
+    source: config.source
+  };
+  if (config.schemaVersion === 2) {
+    const _logs = logs;
+    Object.assign(payload, {
+      'log2amqp-schema-version': '2.1.0',
+      logs: _logs.map(l => {
+        const ret = {};
+        ret[l.type] = l.data;
+        return ret;
+      })
+    });
+    return payload;
+  } else if (config.schemaVersion === 3) {
+    const _logs = logs;
+    return Object.assign(payload, {
+      'log2amqp-schema-version': '3.0.0',
+      logs: _logs
+    });
+  }
+  throw new Error(`Unsupported schema version ${config.schemaVersion}`);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -87,8 +87,8 @@ describe('amqp-logger', function () {
     });
 
     it('should include an indexable key in the message', async function () {
-      const logger = Logger({ meta: { blerg: 'thing' } });
-      await logger.flush();
+      const logger = Logger();
+      await logger.flush({ meta: { blerg: 'thing' } });
       expect(publishStub.callCount).to.equal(1);
       expect(publishStub.lastCall.args[1].meta).to.be.an('object');
       expect(publishStub.lastCall.args[1].meta).to.include.key('blerg');

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,7 @@ describe('amqp-logger', function () {
       const logger = Logger({ meta: { blerg: 'thing' } });
       await logger.flush();
       expect(publishStub.callCount).to.equal(1);
+      expect(publishStub.lastCall.args[1].meta).to.be.an('object');
       expect(publishStub.lastCall.args[1].meta).to.include.key('blerg');
       expect(publishStub.lastCall.args[1].meta.blerg).to.equal('thing');
     });

--- a/test/index.js
+++ b/test/index.js
@@ -16,14 +16,14 @@ describe('amqp-logger', function () {
     it('throws on unsupported schema version', function () {
       expect(() => require('..')({ schemaVersion: -1 })).to.throw();
     });
-    it('should handle bad config', function () {
-      const logger = require('..')({ schemaVersion: 2 });
+    it('should handle bad AMQP config', function () {
+      const logger = require('..')({ source: 'misha', schemaVersion: 2 });
       expect(logger().log).to.be.a('function');
       expect(logger().flush).to.be.a('function');
       return logger().flush();
     });
     it('should reject if you try to flush a logger more than once', async function () {
-      const logger = require('..')({ amqp: {}, schemaVersion: 2 })();
+      const logger = require('..')({ source: 'tom', amqp: {}, schemaVersion: 2 })();
       await logger.flush();
       expect(logger.flush()).to.be.rejected();
     });

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 const chai = require('chai');
 const dirtyChai = require('dirty-chai');
+const chaiAsPromised = require('chai-as-promised');
 const expect = chai.expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 chai.use(dirtyChai);
+chai.use(chaiAsPromised);
 
 describe('amqp-logger', function () {
   describe('unhappy cases', function () {
@@ -14,11 +16,10 @@ describe('amqp-logger', function () {
       expect(logger().flush).to.be.a('function');
       return logger().flush();
     });
-    it('should throw an error if you try to flush a logger more than once', function () {
-      const logger = require('..')({})();
-      return logger.flush().then(function () {
-        expect(logger.flush).to.throw(Error);
-      });
+    it('should reject if you try to flush a logger more than once', async function () {
+      const logger = require('..')({ amqp: {} })();
+      await logger.flush();
+      expect(logger.flush()).to.be.rejected();
     });
   });
   describe('happy cases', function () {


### PR DESCRIPTION
I have added a config to the logger session so you can log something across that log line. (i.e. the line added to the db when you `flush()`.

This means we can add stuff to the top level of the logs to index on more easily.